### PR TITLE
Add .html extension

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -40,7 +40,7 @@ gulp.task('html', function() {
         }))
         .pipe($.ejs({
             dados: dados
-        }).on('error', $.util.log))
+        }, {ext: '.html'}).on('error', $.util.log))
         .pipe(gulp.dest('./dist/'));
 
     dados.lojas.forEach(function(loja){


### PR DESCRIPTION
From https://www.npmjs.com/package/gulp-ejs

> Note: As of v2.0.0 the output file extension is no longer .html by default, you need to specify it, otherwise it will have the same extension of the input file.
